### PR TITLE
refactor take lock with backoff

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -29,6 +29,7 @@ defmodule RedisMutex.Mixfile do
     [
       {:redix, ">= 0.0.0"},
       {:elixir_uuid, "~> 1.2"},
+      {:telemetry, "~> 1.2"},
 
       # Dev and test dependencies
       {:credo, "~> 1.6", only: [:dev, :test]},

--- a/test/redis_mutex_without_mock_test.exs
+++ b/test/redis_mutex_without_mock_test.exs
@@ -39,7 +39,7 @@ defmodule RedisMutexWithoutMockTest do
           try do
             # Make sure this doesn't conflict with other tests in this file
             # because everything gets run async and they could step on each other
-            with_lock("two_threads_one_loses_lock", 500) do
+            with_lock("two_threads_one_loses_lock", timeout: 500) do
               start_time = DateTime.utc_now()
               :timer.sleep(1000)
               end_time = DateTime.utc_now()
@@ -79,7 +79,7 @@ defmodule RedisMutexWithoutMockTest do
       # Kick off a task that will run for a long time, holding the lock
       t =
         Task.async(fn ->
-          with_lock("two_threads_lock_expires", 10_000, 250) do
+          with_lock("two_threads_lock_expires", timeout: 10_000, expiry: 250) do
             :timer.sleep(10_000)
           end
         end)
@@ -89,7 +89,7 @@ defmodule RedisMutexWithoutMockTest do
 
       # try to run another task and see if it gets the lock
       results =
-        with_lock("two_threads_lock_expires", 1000, 500) do
+        with_lock("two_threads_lock_expires", timeout: 1000, expiry: 500) do
           "I RAN!!!"
         end
 


### PR DESCRIPTION
Adds logic to count attempts and timing for lock acquisition + emits those measurements in a Telemetry event for monitoring. Similarly emits a Telemetry event on exception cases.

To apply these changes, I decided to completely break the existing API conventions. I think the new approach makes it easier to grok + handle default values. But, this will make it more difficult to upstream these changes. I'm okay with that tradeoff, but am open to discussion.
